### PR TITLE
Stop notifying build status to #pypa-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,3 @@ script:
 
 after_script:
   - codecov --env TRAVIS_OS_NAME,TOXENV
-
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#pypa-dev"
-    use_notice: true
-    skip_join: true


### PR DESCRIPTION
I think by mistake, 6ac1424f409f8e8757317c323970fce1d584e81e make [Travis CI notify build status to the #pypa-dev IRC channel on Freenode](https://github.com/mijdavis2/pyokta-aws-cli-assume-role/commit/6ac1424f409f8e8757317c323970fce1d584e81e).  As far as I can tell, this project does not seem to belong under the scope of the Python Packaging Authority, and thus shouldn't send build stati there.